### PR TITLE
Página Sobre-Nosotros y re-estructuración de formularios de mensajes

### DIFF
--- a/Institutos/templates/Institutos/Contacto.html
+++ b/Institutos/templates/Institutos/Contacto.html
@@ -1,0 +1,4 @@
+<h2>Contacto</h2>
+{% if error_message %}<p><strong>{{ error_message }}</strong></p>{% endif %}
+
+{% include "Institutos/MensajeForm.html" with id=0 %}

--- a/Institutos/templates/Institutos/Instituto.html
+++ b/Institutos/templates/Institutos/Instituto.html
@@ -45,16 +45,4 @@
 <h2>Mensaje</h2>
 {% if error_message %}<p><strong>{{ error_message }}</strong></p>{% endif %}
 
-<form action="{% url 'nuevo_mensaje' instituto.id %}" method="post">
-    {% csrf_token %}
-    <label for="nombre">Nombre: </label>
-    <input id="nombre" type="text" name="nombre" value="">
-    <label for="telefono">Telefono: </label>
-    <input id="telefono" type="text" name="telefono" value="">
-    <label for="email">Email: </label>
-    <input id="email" type="text" name="email" value="">
-    <label for="mensaje">Mensaje: </label>
-    <input id="mensaje" type="text" name="mensaje" value="">
-
-<input type="submit" value="Enviar" />
-</form>
+{% include "Institutos/MensajeForm.html" with id=instituto.id %}

--- a/Institutos/templates/Institutos/MensajeForm.html
+++ b/Institutos/templates/Institutos/MensajeForm.html
@@ -1,0 +1,13 @@
+<form action="{% url 'nuevo_mensaje' id %}" method="post">
+    {% csrf_token %}
+    <label for="nombre">Nombre: </label>
+    <input id="nombre" type="text" name="nombre" value="">
+    <label for="email">Email: </label>
+    <input id="email" type="text" name="email" value="">
+    <label for="telefono">Telefono: </label>
+    <input id="telefono" type="text" name="telefono" value="">
+    <label for="mensaje">Mensaje: </label>
+    <input id="mensaje" type="text" name="mensaje" value="">
+
+<input type="submit" value="Enviar" />
+</form>

--- a/Institutos/templates/Institutos/Sobre-Nosotros.html
+++ b/Institutos/templates/Institutos/Sobre-Nosotros.html
@@ -1,0 +1,12 @@
+<h2>Sobre nosotros</h2>
+TuProfe.com.uy no es un sitio web cualquiera...
+Es la página de consulta de los estudiantes que quieren buscar profesores particulares.
+Fue creada por un grupo de alumnos, que como vos, necesitó de la mano de un profe para salvar una materia.
+
+¿Alguna vez guardaste el volante del profesor que justo ahora estás buscando?
+No te preocupes... ¡no los guardes más!
+En TuProfe vas a encontrar lo que estás necesitando: un sencillo y práctico sistema de búsqueda, pensado para garantizar la fácil navegación, el acceso veloz y ordenado a la información las 24 hs del día.
+
+Sumate a la búsqueda...
+
+{% include "Institutos/Contacto.html" %}

--- a/Institutos/urls.py
+++ b/Institutos/urls.py
@@ -7,9 +7,10 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('on_login', views.on_login, name='on_login'),
-    path('perfil', views.perfil, name='perfil'),
-    path('buscar', views.buscar, name='buscar'),
+    path('Perfil', views.perfil, name='perfil'),
+    path('Buscar', views.buscar, name='buscar'),
     path('Instituto/<int:instituto_id>/', views.instituto, name='instituto'),
-    path('Instituto/<int:instituto_id>/nuevo_mensaje', views.nuevo_mensaje, name='nuevo_mensaje'),
-    path('contacto', views.contacto, name='contacto'),
+    path('Instituto/<int:instituto_id>/Nuevo-Mensaje', views.nuevo_mensaje, name='nuevo_mensaje'),
+    path('Contacto', views.contacto, name='contacto'),
+    path('Sobre-Nosotros', views.sobre_nosotros, name='sobre_nosotros'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/Institutos/urls.py
+++ b/Institutos/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path('buscar', views.buscar, name='buscar'),
     path('Instituto/<int:instituto_id>/', views.instituto, name='instituto'),
     path('Instituto/<int:instituto_id>/nuevo_mensaje', views.nuevo_mensaje, name='nuevo_mensaje'),
+    path('contacto', views.contacto, name='contacto'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/Institutos/views.py
+++ b/Institutos/views.py
@@ -34,11 +34,18 @@ def instituto(request, instituto_id):
     return render(request, 'Institutos/Instituto.html', {'instituto': instituto})
 
 def nuevo_mensaje(request, instituto_id):
-    instituto = get_object_or_404(Instituto, pk=instituto_id)
     m = Mensaje(nombre=request.POST['nombre'], fecha=timezone.now())
     m.telefono = request.POST['telefono']
     m.email = request.POST['email']
     m.mensaje = request.POST['mensaje']
-    m.instituto = instituto
+    if instituto_id != 0:
+        instituto = get_object_or_404(Instituto, pk=instituto_id)
+        m.instituto = instituto
     m.save()
-    return HttpResponseRedirect(reverse('instituto', args=(instituto.id,)))
+    if instituto_id != 0:
+        return HttpResponseRedirect(reverse('instituto', args=(instituto.id,)))
+    else:
+        return HttpResponseRedirect(reverse('contacto'))
+    
+def contacto(request):
+    return render(request, 'Institutos/Contacto.html')

--- a/Institutos/views.py
+++ b/Institutos/views.py
@@ -49,3 +49,6 @@ def nuevo_mensaje(request, instituto_id):
     
 def contacto(request):
     return render(request, 'Institutos/Contacto.html')
+
+def sobre_nosotros(request):
+    return render(request, 'Institutos/Sobre-Nosotros.html')


### PR DESCRIPTION
Este PR re-estructura la página de contacto para que pueda ser utilizada desde la nueva página de Sobre-Nosotros, y pueda reutilizar el template del formulario.
También se cambiaron las url para mantener coherentes su formato (comiencen en mayúscula y separen las palabras con guiones).

Como probar:
* Acceder a http://127.0.0.1:8000/Contacto y registrar un mensaje
* Acceder a http://127.0.0.1:8000/Sobre-Nosotros y registrar un mensaje
* Validar en la página de administración que ambos mensajes no tiene instituto asociado (es un mensaje hacia nosotros)
* Acceder a la página de un instituto a través del listado http://127.0.0.1:8000/Buscar
* Registrar un mensaje a dicho instituto
* Ir a http://127.0.0.1:8000/login/ y acceder con las credenciales de dicho instituto
* Validar que el mensaje registrado esté listado en la página http://127.0.0.1:8000/Perfil